### PR TITLE
Fix trailingFunctionCommas bugs

### DIFF
--- a/src/utils/removeTrailingComma.js
+++ b/src/utils/removeTrailingComma.js
@@ -6,7 +6,11 @@ export default function removeTrailingComma(code, c) {
 		}
 
 		if (code.original[c] === '/') {
-			c = code.original.indexOf(code.original[c + 1] === '/' ? '\n' : '*/', c) + 1;
+			if (code.original[c + 1] === '/') {
+				c = code.original.indexOf('\n', c);
+			} else {
+				c = code.original.indexOf('*/', c) + 1;
+			}
 		}
 		c += 1;
 	}

--- a/test/samples/trailing-function-commas.js
+++ b/test/samples/trailing-function-commas.js
@@ -95,4 +95,28 @@ module.exports = [
 		output: `
 			function f(a/*a*/) {}`
 	},
+
+	{
+		description: 'does not freeze on multiline calls without trailing comma',
+
+		input: `
+			f(a//
+)`,
+
+		output: `
+			f(a//
+)`
+	},
+
+	{
+		description: 'does not remove commas after closing parens',
+
+		input: `
+			function x(a//
+){return{b:1,c:2}}`,
+
+		output: `
+			function x(a//
+){return{b:1,c:2}}`
+	}
 ];


### PR DESCRIPTION
- Fixes #192 (infinite loop on commented multiline calls without trailing comma).
- Fixes #175 (revoming a comma outside the scope of a function call).

cc @adrianheine 