### PR TITLE
 Fix transpiling string-keyed properties with whitespaces before colons

### DIFF
--- a/src/program/types/ObjectExpression.js
+++ b/src/program/types/ObjectExpression.js
@@ -201,7 +201,7 @@ export default class ObjectExpression extends Node {
 					if (prop.key.type === 'Literal' && !prop.computed) {
 						code.overwrite(
 							prop.start,
-							prop.key.end + 1,
+							prop.value.start,
 							'[' + code.slice(prop.start, prop.key.end) + '] = '
 						);
 					} else if (prop.shorthand || (prop.method && !prop.computed && transforms.conciseMethodProperty)) {

--- a/test/samples/object-properties.js
+++ b/test/samples/object-properties.js
@@ -127,6 +127,20 @@ module.exports = [
 	},
 
 	{
+		description: 'transpiles string-keyed properties after computed properties with excessive whitespaces after the key',
+
+		input: `
+			fn({['computed']: 1, 'some-var':2, 'some-var-2': 3, 'some-var-3' :4, 'some-var-4'    : 5, a: 6});
+		`,
+
+		output: `
+			var obj;
+
+			fn(( obj = {}, obj['computed'] = 1, obj['some-var'] = 2, obj['some-var-2'] = 3, obj['some-var-3'] = 4, obj['some-var-4'] = 5, obj.a = 6, obj ));
+		`,
+	},
+
+	{
 		description: 'avoids shadowing free variables with method names (#166)',
 		input: `
 			let x = {


### PR DESCRIPTION
First, sorry for not creating the issue first.

I've found that bublé produces incorrect results when a string-keyed property in an object which starts with a computed property has whitespaces before colons. I added a test case for it so please take a look.

I think it's already mentioned in https://github.com/bublejs/buble/pull/91#discussion_r161163431.