### PR TITLE
Get rid of os-homedir dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1175,11 +1175,6 @@
         "wordwrap": "1.0.0"
       }
     },
-    "os-homedir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-2.0.0.tgz",
-      "integrity": "sha512-saRNz0DSC5C/I++gFIaJTXoFJMRwiP5zHar5vV3xQ2TkgEw6hDCcU5F272JjUylpiVgBrZNQHnfjkLabTfb92Q=="
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "chalk": "^2.4.2",
     "magic-string": "^0.25.3",
     "minimist": "^1.2.0",
-    "os-homedir": "^2.0.0",
     "regexpu-core": "^4.5.4"
   }
 }

--- a/register.js
+++ b/register.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 var crypto = require('crypto');
-var homedir = require('os-homedir');
+var homedir = require('os').homedir;
 var buble = require('./');
 
 var original = require.extensions[ '.js' ];


### PR DESCRIPTION
Fixes the following warning when installing `buble` v0.19.8:

```
npm WARN deprecated os-homedir@2.0.0: This is not needed anymore. Use `require('os').homedir()` instead.
```

`os-homedir` isn't needed [since Node v2.3.0](https://nodejs.org/api/os.html#os_os_homedir).