### PR TITLE
Fix name collision in `A = class extends A {}`

### DIFF
--- a/src/program/types/ClassExpression.js
+++ b/src/program/types/ClassExpression.js
@@ -19,8 +19,10 @@ export default class ClassExpression extends Node {
 
 	transpile(code, transforms) {
 		if (transforms.classes) {
-			const superName =
-				this.superClass && (this.superClass.name || 'superclass');
+			let superName = this.superClass && (this.superClass.name || 'superclass');
+			if (superName === this.name) {
+				superName = this.findScope(true).createIdentifier(this.name);
+			}
 
 			const i0 = this.getIndentation();
 			const i1 = i0 + code.getIndentString();

--- a/test/samples/classes.js
+++ b/test/samples/classes.js
@@ -1229,6 +1229,27 @@ module.exports = [
 	},
 
 	{
+		description: "don't collide with superclass name (#196)",
+
+		input: `
+			A = class extends A {}
+		`,
+		output: `
+			A = /*@__PURE__*/(function (A$1) {
+				function A () {
+					A$1.apply(this, arguments);
+				}if ( A$1 ) A.__proto__ = A$1;
+				A.prototype = Object.create( A$1 && A$1.prototype );
+				A.prototype.constructor = A;
+
+				
+
+				return A;
+			}(A))
+		`
+	},
+
+	{
 		description: "transpiles class with super class in arrow function (#150)",
 
 		input: `


### PR DESCRIPTION
If the name of the subclass is identical to the name of the superclass,
use a different variable name for the superclass inside the class
function expression.

Fixes #196