### PR TITLE
fix: Make JSX respect advanced white-space characters (fixes #217)

### DIFF
--- a/src/program/types/JSXElement.js
+++ b/src/program/types/JSXElement.js
@@ -2,15 +2,13 @@ import Node from '../Node.js';
 
 function normalise(str, removeTrailingWhitespace) {
 
-	str = str.replace(/\u00a0/g, '&nbsp;');
-
 	if (removeTrailingWhitespace && /\n/.test(str)) {
-		str = str.replace(/\s+$/, '');
+		str = str.replace(/[ \f\n\r\t\v]+$/, '');
 	}
 
 	str = str
-		.replace(/^\n\r?\s+/, '') // remove leading newline + space
-		.replace(/\s*\n\r?\s*/gm, ' '); // replace newlines with spaces
+		.replace(/^\n\r?[ \f\n\r\t\v]+/, '') // remove leading newline + space
+		.replace(/[ \f\n\r\t\v]*\n\r?[ \f\n\r\t\v]*/gm, ' '); // replace newlines with spaces
 
 	// TODO prefer single quotes?
 	return JSON.stringify(str);
@@ -24,7 +22,7 @@ export default class JSXElement extends Node {
 			if (child.type !== 'JSXText') return true;
 
 			// remove whitespace-only literals, unless on a single line
-			return /\S/.test(child.raw) || !/\n/.test(child.raw);
+			return /[^ \f\n\r\t\v]/.test(child.raw) || !/\n/.test(child.raw);
 		});
 
 		if (children.length) {

--- a/test/samples/jsx.js
+++ b/test/samples/jsx.js
@@ -281,17 +281,18 @@ module.exports = [
 	},
 
 	{
-		description: 'handles non-breaking white-space entities',
+		description: 'respects non-breaking and advanced white-space characters',
 
 		input: `
 			<div>
-				<a>1</a>&nbsp;
-				&nbsp;
+				<a>\u00a01\u00a0</a>&nbsp;
+				&nbsp;\u00a0
+				\u2004\u2000
 			</div>
 		`,
 		output: `
 			React.createElement( 'div', null,
-				React.createElement( 'a', null, "1" ), "&nbsp; &nbsp;")
+				React.createElement( 'a', null, "\u00a01\u00a0" ), "\u00a0 \u00a0\u00a0 \u2004\u2000")
 		`
 	},
 
@@ -300,12 +301,12 @@ module.exports = [
 
 		input: `
 			<div>
-				<a>1&lt;</a>&nbsp;
+				<a>1&lt;&aacute;</a>&nbsp;
 			</div>
 		`,
 		output: `
 			React.createElement( 'div', null,
-				React.createElement( 'a', null, "1<" ), "&nbsp;")
+				React.createElement( 'a', null, "1<á" ), "\u00a0")
 		`
 	}
 ];


### PR DESCRIPTION
HTML only collapses normal space, tabs and newlines.
React's JSX (and Babel) traditionally also does that.

Bublé, however, has until now greedily killed all types of spaces,
except for `&nbsp;` which it turned into HTML-escaped entity,
which in turn breaks the text-node rendering in Mithril.js and Hyperscript.js.

(See #217  for more info)