### PR TITLE
Fix/null init forstatement

### DIFF
--- a/src/program/types/ForStatement.js
+++ b/src/program/types/ForStatement.js
@@ -13,7 +13,7 @@ export default class ForStatement extends LoopStatement {
 
 		if (this.shouldRewriteAsFunction) {
 			// which variables are declared in the init statement?
-			const names = this.init.type === 'VariableDeclaration'
+			const names = this.init && this.init.type === 'VariableDeclaration'
 				? this.init.declarations.map(declarator => extractNames(declarator.id))
 				: [];
 

--- a/test/samples/for-statement.js
+++ b/test/samples/for-statement.js
@@ -1,0 +1,25 @@
+module.exports = [
+	{
+		description: 'transpiles for statement without init and update',
+		input: `
+		for (;idx < sw.tabs.length;) {
+			let t = sw.tabs[idx];
+			if (!newTabs.find(nt => nt._id === t._id)) {
+				updateWindowFromBg({action: 'tabRemoved', tid: t._id, wid: sw._id, id: ++eventId});
+			} else {
+				idx++;
+			}
+		}`,
+		output: `
+		var loop = function (  ) {
+			var t = sw.tabs[idx];
+			if (!newTabs.find(function (nt) { return nt._id === t._id; })) {
+				updateWindowFromBg({action: 'tabRemoved', tid: t._id, wid: sw._id, id: ++eventId});
+			} else {
+				idx++;
+			}
+		};
+
+		for (;idx < sw.tabs.length;) loop(  );`
+	}
+];


### PR DESCRIPTION
**Exception transpiling the following snippet**

```javascript
for (; idx < sw.tabs.length;) {
	let t = sw.tabs[idx];
	if (!newTabs.find(nt => nt._id === t._id)) {
		updateWindowFromBg({action: 'tabRemoved', tid: t._id, wid: sw._id, id: ++eventId});
	} else {
		idx++;
	}
}
```

**Error**
TypeError: Cannot read property 'type' of null