### PR TITLE
fix: make letConst transpilation add explicit keys when appropriate

### DIFF
--- a/src/program/BlockStatement.js
+++ b/src/program/BlockStatement.js
@@ -351,6 +351,7 @@ export default class BlockStatement extends Node {
 					const alias = this.scope.createIdentifier(name);
 
 					if (name !== alias) {
+						const declarationParent = declaration.node.parent;
 						declaration.name = alias;
 						code.overwrite(
 							declaration.node.start,
@@ -358,12 +359,20 @@ export default class BlockStatement extends Node {
 							alias,
 							{ storeName: true }
 						);
+						if (declarationParent.type === 'Property' && declarationParent.shorthand) {
+							declarationParent.shorthand = false;
+							code.prependRight(declaration.node.start,       `${name}: `);
+						}
 
 						for (const identifier of declaration.instances) {
 							identifier.rewritten = true;
+							const identifierParent = identifier.parent;
 							code.overwrite(identifier.start, identifier.end, alias, {
 								storeName: true
 							});
+							if (identifierParent.type === 'Property' && identifierParent.shorthand) {
+								code.prependRight(identifier.start, `${name}: `);
+							}
 						}
 					}
 				}

--- a/test/samples/block-scoping.js
+++ b/test/samples/block-scoping.js
@@ -544,5 +544,43 @@ module.exports = [
 		input: 'if(0);const e=0',
 
 		output: 'if(0){ ; }var e=0'
+	},
+
+	{
+		description: 'properly replaces keys of renamed properties when conciseMethodProperty is false',
+		options: { transforms: { letConst: true, conciseMethodProperty: false } },
+		input: `
+			const x = 1;
+			if (true) {
+				const x = 2;
+				const y = { x };
+			}
+		`,
+		output: `
+			var x = 1;
+			if (true) {
+				var x$1 = 2;
+				var y = { x: x$1 };
+			}
+		`
+	},
+
+	{
+		description: 'properly replaces keys of renamed properties in destructuring when conciseMethodProperty is false',
+		options: { transforms: { letConst: true, destructuring: false } },
+		input: `
+			const x = 1;
+			if (true) {
+				const y = {};
+				const { x } = y;
+			}
+		`,
+		output: `
+			var x = 1;
+			if (true) {
+				var y = {};
+				var { x: x$1 } = y;
+			}
+		`
 	}
 ];


### PR DESCRIPTION
When letConst transpilation is on, buble renames some variables,
such as x->x$1. However, when shorthand properties are used, this
causes the property key to change.
The appropriate fix is to make those properties no longer be
shorthand, so something like { x : x$1 } is used.
This applies both to object literals and object destructuring
patterns.

The destructuring and concise property transpilation options hide
this bug, so this commit only improves the situation for use-cases
where letConst transpilation is used without those options.