### PR TITLE
Fix `handlers[node.type] is not a function` error in for...in loops.

### DIFF
--- a/src/program/types/ForInStatement.js
+++ b/src/program/types/ForInStatement.js
@@ -29,7 +29,7 @@ export default class ForInStatement extends LoopStatement {
 		super.transpile(code, transforms);
 
 		const maybePattern = hasDeclaration ? this.left.declarations[0].id : this.left;
-		if (maybePattern.type !== 'Identifier') {
+		if (maybePattern.type !== 'Identifier' && maybePattern.type !== 'MemberExpression') {
 			this.destructurePattern(code, maybePattern, hasDeclaration);
 		}
 	}

--- a/test/samples/for-statement.js
+++ b/test/samples/for-statement.js
@@ -21,5 +21,17 @@ module.exports = [
 		};
 
 		for (;idx < sw.tabs.length;) loop(  );`
+	},
+
+	{
+		description: 'for in with member expression',
+		input: `
+			for (a[0] in a) {
+			}
+		`,
+		output: `
+			for (a[0] in a) {
+			}
+		`
 	}
 ];


### PR DESCRIPTION
When `for (a[0] in b)` is found, buble threw an error.
This commit fixes the error and adds a test.