### PR TITLE
Fix scoping of variables declared in for loops.

### DIFF
--- a/src/program/types/ForInStatement.js
+++ b/src/program/types/ForInStatement.js
@@ -1,12 +1,25 @@
 import LoopStatement from './shared/LoopStatement.js';
 import destructure from '../../utils/destructure.js';
 import extractNames from '../extractNames.js';
+import Scope from '../Scope.js';
 
 export default class ForInStatement extends LoopStatement {
+	initialise(transforms) {
+		this.createdDeclarations = [];
+
+		this.scope = new Scope({
+			block: true,
+			parent: this.parent.findScope(false),
+			declare: id => this.createdDeclarations.push(id)
+		});
+
+		super.initialise(transforms);
+	}
+
 	findScope(functionScope) {
-		return functionScope || !this.createdScope
+		return functionScope
 			? this.parent.findScope(functionScope)
-			: this.body.scope;
+			: this.scope;
 	}
 
 	transpile(code, transforms) {

--- a/src/program/types/ForOfStatement.js
+++ b/src/program/types/ForOfStatement.js
@@ -1,6 +1,7 @@
 import LoopStatement from './shared/LoopStatement.js';
 import CompileError from '../../utils/CompileError.js';
 import destructure from '../../utils/destructure.js';
+import Scope from '../Scope.js';
 
 export default class ForOfStatement extends LoopStatement {
 	initialise(transforms) {
@@ -8,7 +9,22 @@ export default class ForOfStatement extends LoopStatement {
 			CompileError.missingTransform("for-of statements", "forOf", this, "dangerousForOf");
 		if (this.await && transforms.asyncAwait)
 			CompileError.missingTransform("for-await-of statements", "asyncAwait", this);
+
+		this.createdDeclarations = [];
+
+		this.scope = new Scope({
+			block: true,
+			parent: this.parent.findScope(false),
+			declare: id => this.createdDeclarations.push(id)
+		});
+
 		super.initialise(transforms);
+	}
+
+	findScope(functionScope) {
+		return functionScope
+			? this.parent.findScope(functionScope)
+			: this.scope;
 	}
 
 	transpile(code, transforms) {

--- a/src/program/types/ForStatement.js
+++ b/src/program/types/ForStatement.js
@@ -1,11 +1,24 @@
 import LoopStatement from './shared/LoopStatement.js';
 import extractNames from '../extractNames.js';
+import Scope from '../Scope.js';
 
 export default class ForStatement extends LoopStatement {
+	initialise(transforms) {
+		this.createdDeclarations = [];
+
+		this.scope = new Scope({
+			block: true,
+			parent: this.parent.findScope(false),
+			declare: id => this.createdDeclarations.push(id)
+		});
+
+		super.initialise(transforms);
+	}
+
 	findScope(functionScope) {
-		return functionScope || !this.createdScope
+		return functionScope
 			? this.parent.findScope(functionScope)
-			: this.body.scope;
+			: this.scope;
 	}
 
 	transpile(code, transforms) {

--- a/src/program/types/shared/LoopStatement.js
+++ b/src/program/types/shared/LoopStatement.js
@@ -18,16 +18,24 @@ export default class LoopStatement extends Node {
 		this.thisRefs = [];
 
 		super.initialise(transforms);
+		if (this.scope) {
+			this.scope.consolidate();
+		}
+
+		const declarations = Object.assign({}, this.body.scope.declarations);
+		if (this.scope) {
+			Object.assign(declarations, this.scope.declarations);
+		}
 
 		if (transforms.letConst) {
 			// see if any block-scoped declarations are referenced
 			// inside function expressions
-			const names = Object.keys(this.body.scope.declarations);
+			const names = Object.keys(declarations);
 
 			let i = names.length;
 			while (i--) {
 				const name = names[i];
-				const declaration = this.body.scope.declarations[name];
+				const declaration = declarations[name];
 
 				let j = declaration.instances.length;
 				while (j--) {

--- a/test/samples/block-scoping.js
+++ b/test/samples/block-scoping.js
@@ -86,6 +86,53 @@ module.exports = [
 	},
 
 	{
+		description: 'allows reassignment of mutable variables that are shadowed by constants in for loops',
+		input: `
+			for (let i = 0; i < 10; i++) {
+				const i = 1;
+			}
+		`,
+		output: `
+			for (var i = 0; i < 10; i++) {
+				var i$1 = 1;
+			}
+		`
+	},
+
+	{
+		description: 'allows reassignment of mutable variables that are shadowed by constants in for in loops',
+		input: `
+			let i = { x: 1 };
+			for (i in i) {
+				const i = 1;
+			}
+		`,
+		output: `
+			var i = { x: 1 };
+			for (i in i) {
+				var i$1 = 1;
+			}
+		`
+	},
+
+	{
+		description: 'allows reassignment of mutable variables that are shadowed by constants in for of loops',
+		input: `
+			let i = { x: 1 };
+			for (i of i) {
+				const i = 1;
+			}
+		`,
+		output: `
+			var i = { x: 1 };
+			for (i of i) {
+				var i$1 = 1;
+			}
+		`,
+		options: { transforms: { forOf: false } }
+	},
+
+	{
 		description: 'disallows destructured reassignment to constants, short-hand property',
 		input: `
 			const x = 1;


### PR DESCRIPTION
This fixes an issue encountered when compiling:
```
for (let i = 0; i < 10; i++) {
   const i = ...;
   ...
}
```

Buble incorrectly threw an error due to the 'i' in 'i++' being
incorrectly identified as a constant.
This commits makes it so for, for in and for of loops have their
own scope.

The way the variable declarations are handled to calculate `shouldRewriteAsFunction` is not ideal. It only got the bare minimum changes to pass the existing tests, so current limitations still apply.