### PR TITLE
Prevent labels from being renamed due to let/const transpilation.

### DIFF
--- a/src/program/types/Identifier.js
+++ b/src/program/types/Identifier.js
@@ -16,6 +16,10 @@ export default class Identifier extends Node {
 	}
 
 	initialise(transforms) {
+		if (this.isLabel()) {
+			return;
+		}
+
 		if (isReference(this, this.parent)) {
 			if (
 				transforms.arrow &&
@@ -40,6 +44,15 @@ export default class Identifier extends Node {
 			}
 
 			this.findScope(false).addReference(this);
+		}
+	}
+
+	isLabel() {
+		switch (this.parent.type) {
+			case 'BreakStatement': return true;
+			case 'ContinueStatement': return true;
+			case 'LabeledStatement': return true;
+			default: return false;
 		}
 	}
 

--- a/test/samples/loops.js
+++ b/test/samples/loops.js
@@ -855,5 +855,57 @@ module.exports = [
 				var b = ref[1]; if ( b === void 0 ) b = "_";
 
 				f(a, b) }`
+	},
+
+	{
+		description: 'labelled breaks/continues are not renamed',
+
+		input: `
+			function f(x) {
+				x:
+				for (let x = 0;;) {
+					if (x > 1) { break x; }
+					else { continue x; }
+				}
+			}
+		`,
+
+		output: `
+			function f(x) {
+				x:
+				for (var x$1 = 0;;) {
+					if (x$1 > 1) { break x; }
+					else { continue x; }
+				}
+			}
+		`
+	},
+
+	{
+		description: 'Labels are not renamed',
+
+		input: `
+			function f() {
+				let x = 1;
+				{
+					let x = 2;
+					x:
+					for (;;) {
+					}
+				}
+			}
+		`,
+
+		output: `
+			function f() {
+				var x = 1;
+				{
+					var x$1 = 2;
+					x:
+					for (;;) {
+					}
+				}
+			}
+		`
 	}
 ];


### PR DESCRIPTION
When a label has the same name as a variable that has been renamed due to let/const transpilation, the label may also be renamed.
This should not happen, since labels do not follow the same scope rules as variables.
This commit prevents labeled continues and label statements from being renamed, fixing the issue.
Labeled break were not buggy, as breaks do not initialise their children anyway, but this commit also adds breaks to the list of renames to skip, for consistency.

See the added tests for examples that were previously buggy.