### PR TITLE
Fix recognition of catch-declared variables

### DIFF
--- a/scripts/test262-data.js
+++ b/scripts/test262-data.js
@@ -514,7 +514,7 @@ exports.file_list = [
 		//"language/statements/block/scope-lex-open.js",
 		"language/statements/for-of/scope-head-lex-open.js",
 		"language/statements/for-of/scope-body-lex-open.js",
-		"language/statements/try/scope-catch-param-lex-open.js",
+		//"language/statements/try/scope-catch-param-lex-open.js",
 		//"language/statements/try/scope-catch-block-lex-open.js",
 		//"language/expressions/class/scope-name-lex-close.js",
 		//"language/expressions/call/scope-lex-close.js",

--- a/src/program/types/CatchClause.js
+++ b/src/program/types/CatchClause.js
@@ -1,0 +1,25 @@
+import Node from '../Node.js';
+import Scope from '../Scope.js';
+
+export default class CatchClause extends Node {
+	initialise(transforms) {
+		this.createdDeclarations = [];
+		this.scope = new Scope({
+			block: true,
+			parent: this.parent.findScope(false),
+			declare: id => this.createdDeclarations.push(id)
+		});
+
+		this.scope.addDeclaration(this.param, 'catch');
+
+		super.initialise(transforms);
+		this.scope.consolidate();
+	}
+
+	findScope(functionScope) {
+		return functionScope
+			? this.parent.findScope(functionScope)
+			: this.scope;
+	}
+}
+

--- a/src/program/types/index.js
+++ b/src/program/types/index.js
@@ -5,6 +5,7 @@ import AwaitExpression from './AwaitExpression.js';
 import BinaryExpression from './BinaryExpression.js';
 import BreakStatement from './BreakStatement.js';
 import CallExpression from './CallExpression.js';
+import CatchClause from './CatchClause.js';
 import ClassBody from './ClassBody.js';
 import ClassDeclaration from './ClassDeclaration.js';
 import ClassExpression from './ClassExpression.js';
@@ -55,6 +56,7 @@ export default {
 	BinaryExpression,
 	BreakStatement,
 	CallExpression,
+	CatchClause,
 	ClassBody,
 	ClassDeclaration,
 	ClassExpression,

--- a/test/samples/misc.js
+++ b/test/samples/misc.js
@@ -185,5 +185,28 @@ module.exports = [
 				return bar;
 			}
 		`
+	},
+
+	{
+		description: 'catch clauses have their own scope',
+		input: `
+			const l = 2;
+			try {
+				throw new Error();
+			} catch(l) {
+				l = 1;
+				alert(l);
+			}
+		`,
+		output: `
+			var l = 2;
+			try {
+				throw new Error();
+			} catch(l$1) {
+				l$1 = 1;
+				alert(l$1);
+			}
+		`
 	}
+
 ];


### PR DESCRIPTION
Buble did not recognize variables declared in catch clauses, causing the code in the added unit test to fail to compile.