### PR TITLE
Rewrite ObjectExpression transpilation

### DIFF
--- a/src/program/types/ObjectExpression.js
+++ b/src/program/types/ObjectExpression.js
@@ -5,19 +5,66 @@ export default class ObjectExpression extends Node {
 	transpile(code, transforms) {
 		super.transpile(code, transforms);
 
-		let firstPropertyStart = this.start + 1;
-		let spreadPropertyCount = 0;
-		let computedPropertyCount = 0;
-		let firstSpreadProperty = null;
-		let firstComputedProperty = null;
+		// The output of this transpilation takes one of three forms:
+		//
+		//  * An object expression
+		//
+		//  * A call to objectAssign which contains exactly one object expression
+		//    as the initial argument, followed by one or more additional arguments
+		//
+		//  * A sequence of assignments, either as statements or a comma-joined
+		//    expression, where a variable is initialized with one of the two
+		//    previous forms and then mutated with property assignments and/or
+		//    calls to objectAssign
+		//
+		// (Note that regardless of the specifics of the form, exactly one object
+		// expression will be produced (not counting object expressions that
+		// started out as children of this one). This is in contrast to an earlier
+		// version of this function, which could produce output containing multiple
+		// object expressions, such as `Object.assign({a: 1}, b, {c: 2})`.)
+		//
+		// To generate this output, the below loop transitions between three
+		// states: an INITIAL state where simple properties are permitted to remain
+		// in the original object expression as-is, a SPREAD state where
+		// consecutive spread properties are appended to an objectAssign call, and
+		// an ASSIGNMENTS state where properties of any non-spread type are
+		// assigned to an object initialized by the previous states.
+		//
+		// Leaving the INITIAL state causes the closing `}` to be moved forward to
+		// the current position, forming the (possibly empty) initial object
+		// expression for whichever form is indicated by the new state. If INITIAL
+		// transitions into SPREAD, a call to objectAssign is prepended to the
+		// entire result fragment. The first time either INITIAL or SPREAD
+		// transitions into ASSIGNMENTS, an `( obj = ` wrapper is prepended to the
+		// entire result fragment. Transitioning from ASSIGNMENTS into SPREAD
+		// starts an objectAssign call at the current position in the code, instead
+		// of prepending it to the entire result. Transitioning from SPREAD to
+		// ASSIGNMENTS closes the current objectAssign call, whether it was created
+		// by a transition from INITIAL or from ASSIGNMENTS. Transititioning into
+		// INITIAL is not possible.
+		//
+		// At the end of the loop, there will be at most one objectAssign call
+		// open, and at most one `( obj = ` wrapper open, both of which will be
+		// closed in that order.
+
+		const STATE_INITIAL = 0, STATE_SPREAD = 1, STATE_ASSIGNMENTS = 2;
+		let state = STATE_INITIAL;
+
+		let hasAssignments = false;
+		let assignmentSeparator;
+		let isSimpleAssignment;
+		let name;
 
 		for (let i = 0; i < this.properties.length; ++i) {
 			const prop = this.properties[i];
+			const moveStart = i > 0 ? this.properties[i - 1].end : this.start + 1;
+			const prevState = state;
+
 			if (prop.type === 'SpreadElement') {
 				// First see if we can inline the spread, to save needing objectAssign.
 				const argument = prop.argument;
 				if (
-					argument.type === 'ObjectExpression' || (
+					argument.type === 'ObjectExpression' && safeToInline(argument) || (
 						argument.type === 'Literal' &&
 						typeof argument.value !== 'string'
 					)
@@ -39,230 +86,169 @@ export default class ObjectExpression extends Node {
 						this.properties.splice(i, 1);
 						i--;
 					}
-				} else {
-					spreadPropertyCount += 1;
-					if (firstSpreadProperty === null) firstSpreadProperty = i;
+					continue;
+				} else if (state === STATE_ASSIGNMENTS || transforms.objectRestSpread) {
+					// If we have already started assigning to the object, we have to use
+					// objectAssign even if objectRestSpread is off.
+					if (!this.program.options.objectAssign) {
+						throw new CompileError(
+							"Object spread operator requires specified objectAssign option with 'Object.assign' or polyfill helper.",
+							this
+						);
+					}
+
+					state = STATE_SPREAD;
 				}
-			} else if (prop.computed && transforms.computedProperty) {
-				computedPropertyCount += 1;
-				if (firstComputedProperty === null) firstComputedProperty = i;
-			}
-		}
-
-		if (spreadPropertyCount && !transforms.objectRestSpread && !(computedPropertyCount && transforms.computedProperty)) {
-			spreadPropertyCount = 0;
-			firstSpreadProperty = null;
-		} else if (spreadPropertyCount) {
-			if (!this.program.options.objectAssign) {
-				throw new CompileError(
-					"Object spread operator requires specified objectAssign option with 'Object.assign' or polyfill helper.",
-					this
-				);
-			}
-			let i = this.properties.length;
-			while (i--) {
-				const prop = this.properties[i];
-
-				// enclose run of non-spread properties in curlies
-				if (prop.type === 'Property' && !computedPropertyCount) {
-					const lastProp = this.properties[i - 1];
-					const nextProp = this.properties[i + 1];
-
-					if (!lastProp || lastProp.type !== 'Property') {
-						code.prependRight(prop.start, '{');
+			} else if (
+				prevState === STATE_SPREAD ||
+				prevState === STATE_INITIAL && prop.computed && transforms.computedProperty
+			) {
+				if (!hasAssignments) {
+					hasAssignments = true;
+					if (
+						this.parent.type === 'VariableDeclarator' &&
+						this.parent.parent.declarations.length === 1 &&
+						this.parent.id.type === 'Identifier'
+					) {
+						isSimpleAssignment = true;
+						name = this.parent.id.alias || this.parent.id.name; // TODO is this right?
+					} else if (
+						this.parent.type === 'AssignmentExpression' &&
+						this.parent.parent.type === 'ExpressionStatement' &&
+						this.parent.left.type === 'Identifier'
+					) {
+						isSimpleAssignment = true;
+						name = this.parent.left.alias || this.parent.left.name; // TODO is this right?
+					} else if (
+						this.parent.type === 'AssignmentPattern' &&
+						this.parent.left.type === 'Identifier'
+					) {
+						isSimpleAssignment = true;
+						name = this.parent.left.alias || this.parent.left.name; // TODO is this right?
 					}
 
-					if (!nextProp || nextProp.type !== 'Property') {
-						code.appendLeft(prop.end, '}');
+					if (isSimpleAssignment) {
+						// handle block scoping
+						name = this.findScope(false).resolveName(name);
+
+						assignmentSeparator = `;\n${this.getIndentation()}`;
+					} else {
+						name = this.findScope(true).createDeclaration('obj');
+
+						assignmentSeparator = ', ';
+
+						// Close `( obj = ...` expression
+						code.prependRight(this.start, `( ${name} = `);
 					}
+				}
+
+				state = STATE_ASSIGNMENTS;
+			}
+
+
+			if (prevState === STATE_SPREAD && state !== STATE_SPREAD) {
+				// Close objectAssign call
+				code.appendLeft(moveStart, ')');
+			} else if (prevState === STATE_INITIAL && state !== STATE_INITIAL) {
+				// Close the initial object literal by moving the end brace forward
+
+				const lastPropertyEnd = this.properties[this.properties.length - 1].end;
+				let beginEnd = i > 0 ? lastPropertyEnd : this.end - 1;
+
+				// Trim trailing comma because it can easily become a leading comma which is illegal
+				if (code.original[beginEnd] == ',') ++beginEnd;
+				const closing = code.slice(beginEnd, this.end);
+				code.prependLeft(moveStart, closing);
+				code.remove(lastPropertyEnd, this.end);
+			}
+
+			if (
+				state === STATE_SPREAD && i === 0 || // Remove initial whitespace if object is empty
+				state === STATE_ASSIGNMENTS ||       // Remove property separators
+				prevState === STATE_ASSIGNMENTS      // (to be replaced immediately below with normalized ones)
+			) {
+				code.remove(moveStart, prop.start);
+			}
+
+			if (state === STATE_ASSIGNMENTS || prevState === STATE_ASSIGNMENTS) {
+				code.appendLeft(prop.start, assignmentSeparator);
+			}
+
+			if (state === STATE_SPREAD) {
+				// Open objectAssign call
+				if (prevState === STATE_INITIAL) {
+					code.prependRight(this.start, `${this.program.options.objectAssign}(`);
+					// For spreads that begin after a non-zero number of regular
+					// properties, we can reuse the separator that immediately precedes
+					// the spread. But if the spread is the first thing in the object, an
+					// argument separator must be synthesized.
+					if (i === 0) {
+						code.appendRight(prop.argument.start, ', ');
+					}
+				} else if (prevState === STATE_ASSIGNMENTS) {
+					code.appendRight(prop.argument.start, `${this.program.options.objectAssign}(${name}, `);
 				}
 
 				// Remove ellipsis on spread property
-				if (prop.type === 'SpreadElement') {
-					code.remove(prop.start, prop.argument.start);
-					code.remove(prop.argument.end, prop.end);
-				}
-			}
+				code.remove(prop.start, prop.argument.start);
 
-			// wrap the whole thing in Object.assign
-			firstPropertyStart = this.properties[0].start;
-			if (!computedPropertyCount) {
-				code.overwrite(
-					this.start,
-					firstPropertyStart,
-					`${this.program.options.objectAssign}({}, `
-				);
-				code.overwrite(
-					this.properties[this.properties.length - 1].end,
-					this.end,
-					')'
-				);
-			} else if (this.properties[0].type === 'SpreadElement') {
-				code.overwrite(
-					this.start,
-					firstPropertyStart,
-					`${this.program.options.objectAssign}({}, `
-				);
-				code.remove(this.end - 1, this.end);
-				code.appendRight(this.end, ')');
-			} else {
-				code.prependLeft(this.start, `${this.program.options.objectAssign}(`);
-				code.appendRight(this.end, ')');
+			} else if (state === STATE_ASSIGNMENTS) {
+				code.appendLeft(prop.start, prop.key.type === 'Literal' || prop.computed ? name : `${name}.`);
+
+				let c = prop.key.end;
+				if (prop.computed) {
+					while (code.original[c] !== ']') c += 1;
+					c += 1;
+				}
+				if (prop.key.type === 'Literal' && !prop.computed) {
+					code.overwrite(
+						prop.start,
+						prop.value.start,
+						'[' + code.slice(prop.start, prop.key.end) + '] = '
+					);
+				} else if (prop.shorthand || (prop.method && !prop.computed && transforms.conciseMethodProperty)) {
+					// Replace : with = if Property::transpile inserted the :
+					code.overwrite(
+						prop.key.start,
+						prop.key.end,
+						code.slice(prop.key.start, prop.key.end).replace(/:/, ' =')
+					);
+				} else {
+					if (prop.value.start > c) code.remove(c, prop.value.start);
+					code.prependLeft(c, ' = ');
+				}
+
+				// This duplicates behavior from Property::transpile which is disabled
+				// for computed properties or if conciseMethodProperty is false
+				if (prop.method && (prop.computed || !transforms.conciseMethodProperty)) {
+					if (prop.value.generator) code.remove(prop.start, prop.key.start);
+					code.prependRight(prop.value.start, `function${prop.value.generator ? '*' : ''} `);
+				}
 			}
 		}
 
-		if (computedPropertyCount && transforms.computedProperty) {
-			const i0 = this.getIndentation();
+		if (state === STATE_SPREAD) {
+			// Close objectAssign call
+			code.appendLeft(this.end, ')');
+		}
 
-			let isSimpleAssignment;
-			let name;
-
-			if (
-				this.parent.type === 'VariableDeclarator' &&
-				this.parent.parent.declarations.length === 1 &&
-				this.parent.id.type === 'Identifier'
-			) {
-				isSimpleAssignment = true;
-				name = this.parent.id.alias || this.parent.id.name; // TODO is this right?
-			} else if (
-				this.parent.type === 'AssignmentExpression' &&
-				this.parent.parent.type === 'ExpressionStatement' &&
-				this.parent.left.type === 'Identifier'
-			) {
-				isSimpleAssignment = true;
-				name = this.parent.left.alias || this.parent.left.name; // TODO is this right?
-			} else if (
-				this.parent.type === 'AssignmentPattern' &&
-				this.parent.left.type === 'Identifier'
-			) {
-				isSimpleAssignment = true;
-				name = this.parent.left.alias || this.parent.left.name; // TODO is this right?
+		if (hasAssignments && !isSimpleAssignment) {
+			// If the last expression was an objectAssign call, we can do nothing and
+			// use its return value; but otherwise, append the working object.
+			if (state !== STATE_SPREAD) {
+				code.appendLeft(this.end, `, ${name}`);
 			}
-
-			if (spreadPropertyCount) isSimpleAssignment = false;
-
-			// handle block scoping
-			name = this.findScope(false).resolveName(name);
-
-			const start = firstPropertyStart;
-			const end = this.end;
-
-			if (isSimpleAssignment) {
-				// ???
-			} else {
-				if (
-					firstSpreadProperty === null ||
-					firstComputedProperty < firstSpreadProperty
-				) {
-					name = this.findScope(true).createDeclaration('obj');
-
-					code.prependRight(this.start, `( ${name} = `);
-				} else name = null; // We don't actually need this variable
-			}
-
-			const len = this.properties.length;
-			let lastComputedProp;
-			let sawNonComputedProperty = false;
-			let isFirst = true;
-
-			for (let i = 0; i < len; i += 1) {
-				const prop = this.properties[i];
-				let moveStart = i > 0 ? this.properties[i - 1].end : start;
-
-				if (
-					prop.type === 'Property' &&
-					(prop.computed || (lastComputedProp && !spreadPropertyCount))
-				) {
-					if (i === 0) moveStart = this.start + 1; // Trim leading whitespace
-					lastComputedProp = prop;
-
-					if (!name) {
-						name = this.findScope(true).createDeclaration('obj');
-
-						const propId = name + (prop.computed ? '' : '.');
-						code.appendRight(prop.start, `( ${name} = {}, ${propId}`);
-					} else {
-						const propId =
-							(isSimpleAssignment ? `;\n${i0}${name}` : `, ${name}`) +
-							(prop.key.type === 'Literal' || prop.computed ? '' : '.');
-
-						if (moveStart < prop.start) {
-							code.overwrite(moveStart, prop.start, propId);
-						} else {
-							code.prependRight(prop.start, propId);
-						}
-					}
-
-					let c = prop.key.end;
-					if (prop.computed) {
-						while (code.original[c] !== ']') c += 1;
-						c += 1;
-					}
-					if (prop.key.type === 'Literal' && !prop.computed) {
-						code.overwrite(
-							prop.start,
-							prop.value.start,
-							'[' + code.slice(prop.start, prop.key.end) + '] = '
-						);
-					} else if (prop.shorthand || (prop.method && !prop.computed && transforms.conciseMethodProperty)) {
-						// Replace : with = if Property::transpile inserted the :
-						code.overwrite(
-							prop.key.start,
-							prop.key.end,
-							code.slice(prop.key.start, prop.key.end).replace(/:/, ' =')
-						);
-					} else {
-						if (prop.value.start > c) code.remove(c, prop.value.start);
-						code.prependLeft(c, ' = ');
-					}
-
-					// This duplicates behavior from Property::transpile which is disabled
-					// for computed properties or if conciseMethodProperty is false
-					if (prop.method && (prop.computed || !transforms.conciseMethodProperty)) {
-						if (prop.value.generator) code.remove(prop.start, prop.key.start);
-						code.prependRight(prop.value.start, `function${prop.value.generator ? '*' : ''} `);
-					}
-				} else if (prop.type === 'SpreadElement') {
-					if (name && i > 0) {
-						if (!lastComputedProp) {
-							lastComputedProp = this.properties[i - 1];
-						}
-						code.appendLeft(lastComputedProp.end, `, ${name} )`);
-
-						lastComputedProp = null;
-						name = null;
-					}
-				} else {
-					if (!isFirst && spreadPropertyCount) {
-						// We are in an Object.assign context, so we need to wrap regular properties
-						code.prependRight(prop.start, '{');
-						code.appendLeft(prop.end, '}');
-					}
-					sawNonComputedProperty = true;
-				}
-				if (isFirst && (prop.type === 'SpreadElement' || prop.computed)) {
-					let beginEnd = sawNonComputedProperty
-						? this.properties[this.properties.length - 1].end
-						: this.end - 1;
-					// Trim trailing comma because it can easily become a leading comma which is illegal
-					if (code.original[beginEnd] == ',') ++beginEnd;
-					const closing = code.slice(beginEnd, end);
-					code.prependLeft(moveStart, closing);
-					code.remove(beginEnd, end);
-					isFirst = false;
-				}
-
-				// Clean up some extranous whitespace
-				let c = prop.end;
-				if (i < len - 1 && !sawNonComputedProperty) {
-					while (code.original[c] !== ',') c += 1;
-				} else if (i == len - 1) c = this.end;
-				if (prop.end != c) code.overwrite(prop.end, c, '', {contentOnly: true});
-			}
-
-			if (!isSimpleAssignment && name) {
-				code.appendLeft(lastComputedProp.end, `, ${name} )`);
-			}
+			// Close `( obj = ...` expression
+			code.appendLeft(this.end, ' )');
 		}
 	}
+}
+
+function safeToInline(obj) {
+	for (let i = 0; i < obj.properties.length; i++) {
+		if (obj.properties[i].kind !== 'init') {
+			return false;
+		}
+	}
+	return true;
 }

--- a/test/samples/computed-properties.js
+++ b/test/samples/computed-properties.js
@@ -291,5 +291,112 @@ module.exports = [
 			var obj$1;
 var obj = 2; console.log([( obj$1 = {}, obj$1[x] = 1, obj$1 ), obj]);})(3);
 		`
+	},
+
+	{
+		description: 'spread and computed properties in arrow function',
+
+		options: {
+			objectAssign: 'Object.assign'
+		},
+
+		input: `
+			v => v && { ...o, [k]: v };
+		`,
+
+		output: `
+			!function(v) {
+				var obj;
+
+				return v && ( obj = Object.assign({}, o), obj[k] = v, obj );
+			};
+		`
+	},
+
+	{
+		description:
+			'spread and computed properties in arrow function, with the spread in the middle',
+
+		options: {
+			objectAssign: 'Object.assign'
+		},
+
+		input: `
+			v => v && { p, ...o, [k]: v };
+		`,
+
+		output: `
+			!function(v) {
+				var obj;
+
+				return v && ( obj = Object.assign({ p: p }, o), obj[k] = v, obj );
+			};
+		`
+	},
+
+	{
+		description:
+			'many alternating spread, computed, and normal properties in arrow function',
+
+		options: {
+			objectAssign: 'Object.assign'
+		},
+
+		input: `
+			v => v && { p, ...o, q, [k]: v, r, ...s, t };
+		`,
+
+		output: `
+			!function(v) {
+				var obj;
+
+				return v && ( obj = Object.assign({ p: p }, o), obj.q = q, obj[k] = v, obj.r = r, Object.assign(obj, s), obj.t = t, obj );
+			};
+		`
+	},
+
+	{
+		description:
+			'arrow function with nested spread and computed properties (bublejs/buble#212)',
+
+		options: {
+			objectAssign: 'Object.assign'
+		},
+
+		input: `
+			setState(previousState => ({
+				...previousState,
+					field: {
+						...previousState.field,
+						[field]: true
+					}
+			}))
+		`,
+
+		output: `
+			setState(function (previousState) {
+				var obj, obj$1;
+
+				return (( obj$1 = Object.assign({}, previousState), obj$1.field = ( obj = Object.assign({}, previousState.field), obj[field] = true, obj ), obj$1 ));
+			})
+		`
+	},
+
+	{
+		description: 'nested spread and computed properties (bublejs/buble#163)',
+
+		options: {
+			objectAssign: 'Object.assign'
+		},
+
+		input: `
+			({ ...o, [k]: { ...o, [k]: v } });
+		`,
+
+		output: `
+			var obj, obj$1;
+
+			(( obj$1 = Object.assign({}, o), obj$1[k] = ( obj = Object.assign({}, o), obj[k] = v, obj ), obj$1 ));
+		`
 	}
 ];

--- a/test/samples/destructuring.js
+++ b/test/samples/destructuring.js
@@ -933,6 +933,6 @@ var a = x[1];
 		output: `
 var obj;
 var z1 = {};
-z1[b] = Object.assign({}, c, ( obj = {}, obj[d] = 'Hello, World!', obj ))`
+z1[b] = ( obj = Object.assign({}, c), obj[d] = 'Hello, World!', obj )`
 	}
 ];

--- a/test/samples/object-rest-spread.js
+++ b/test/samples/object-rest-spread.js
@@ -28,8 +28,14 @@ module.exports = [
 		options: {
 			objectAssign: 'Object.assign'
 		},
-		input: `var obj = { ...a, b: 1, c: 2 };`,
-		output: `var obj = Object.assign({}, a, {b: 1, c: 2});`
+		input: `
+			var obj = { ...a, b: 1, c: 2 };
+		`,
+		output: `
+			var obj = Object.assign({}, a);
+			obj.b = 1;
+			obj.c = 2;
+		`
 	},
 
 	{
@@ -37,8 +43,15 @@ module.exports = [
 		options: {
 			objectAssign: 'Object.assign'
 		},
-		input: `var obj = { ...a, b: 1, ...d, e};`,
-		output: `var obj = Object.assign({}, a, {b: 1}, d, {e: e});`
+		input: `
+			var obj = { ...a, b: 1, ...d, e};
+		`,
+		output: `
+			var obj = Object.assign({}, a);
+			obj.b = 1;
+			Object.assign(obj, d);
+			obj.e = e;
+		`
 	},
 
 	{
@@ -62,11 +75,17 @@ module.exports = [
 			var a12 = { ...b, [c]:3, d:4 };
 		`,
 		output: `
-			var obj, obj$1, obj$2, obj$3, obj$4, obj$5, obj$6, obj$7, obj$8;
-
-			var a0 = Object.assign(( obj = {}, obj[ x ] = true, obj ), y);
-			var a1 = Object.assign(( obj$1 = {}, obj$1[ w ] = 0, obj$1[ x ] = true, obj$1 ), y);
-			var a2 = Object.assign(( obj$2 = { v: v }, obj$2[ w ] = 0, obj$2[ x ] = true, obj$2 ), y);
+			var a0 = {};
+			a0[ x ] = true;
+			Object.assign(a0, y);
+			var a1 = {};
+			a1[ w ] = 0;
+			a1[ x ] = true;
+			Object.assign(a1, y);
+			var a2 = { v: v };
+			a2[ w ] = 0;
+			a2[ x ] = true;
+			Object.assign(a2, y);
 			var a3 = {};
 			a3[ w ] = 0;
 			a3[ x ] = true;
@@ -74,19 +93,31 @@ module.exports = [
 			a4[ w ] = 0;
 			a4[ x ] = true;
 			a4.y = y;
-			var a5 = Object.assign(( obj$3 = { k : 9 }, obj$3[ x ] = true, obj$3 ), y);
-			var a6 = Object.assign({}, y, ( obj$4 = {}, obj$4[ x ] = true, obj$4 ));
-			var a7 = Object.assign({}, y, ( obj$5 = {}, obj$5[ w ] = 0, obj$5[ x ] = true, obj$5 ));
-			var a8 = Object.assign({ k : 9 }, y, ( obj$6 = {}, obj$6[ x ] = true, obj$6 ));
+			var a5 = { k : 9 };
+			a5[ x ] = true;
+			Object.assign(a5, y);
+			var a6 = Object.assign({}, y);
+			a6[ x ] = true;
+			var a7 = Object.assign({}, y);
+			a7[ w ] = 0;
+			a7[ x ] = true;
+			var a8 = Object.assign({ k : 9 }, y);
+			a8[ x ] = true;
 			var a9 = {};
 			a9[ x ] = true;
 			a9[ y ] = false;
 			a9[ z ] = 9;
-			var a10 = Object.assign(( obj$7 = {}, obj$7[ x ] = true, obj$7 ), y, {p: p}, q);
+			var a10 = {};
+			a10[ x ] = true;
+			Object.assign(a10, y);
+			a10.p = p;
+			Object.assign(a10, q);
 			var a11 = { x: x };
 			a11[c] = 9;
 			a11.y = y;
-			var a12 = Object.assign({}, b, ( obj$8 = {}, obj$8[c] = 3, obj$8 ), {d:4});
+			var a12 = Object.assign({}, b);
+			a12[c] = 3;
+			a12.d = 4;
 		`
 	},
 	{
@@ -136,7 +167,7 @@ module.exports = [
 			var a0 = { [ x ] : true , ... y };
 		`,
 		output: `
-			var a0 = Object.assign({}, {[ x ] : true} , y);
+			var a0 = Object.assign({ [ x ] : true } , y);
 		`,
 	},
 	{
@@ -149,9 +180,9 @@ module.exports = [
 			var a0 = { [ x ] : true , ... y };
 		`,
 		output: `
-			var obj;
-
-			var a0 = Object.assign(( obj = {}, obj[ x ] = true, obj ), y);
+			var a0 = {};
+			a0[ x ] = true;
+			Object.assign(a0, y);
 		`,
 	},
 	{
@@ -178,19 +209,19 @@ module.exports = [
 		output: `
 			var obj, obj$1, obj$2, obj$3, obj$4, obj$5, obj$6, obj$7, obj$8, obj$9, obj$10, obj$11, obj$12;
 
-			f0( Object.assign(( obj = {}, obj[ x ] = true, obj ), y) );
-			f1( Object.assign(( obj$1 = {}, obj$1[ w ] = 0, obj$1[ x ] = true, obj$1 ), y) );
-			f2( Object.assign(( obj$2 = { v: v }, obj$2[ w ] = 0, obj$2[ x ] = true, obj$2 ), y) );
+			f0( ( obj = {}, obj[ x ] = true, Object.assign(obj, y) ) );
+			f1( ( obj$1 = {}, obj$1[ w ] = 0, obj$1[ x ] = true, Object.assign(obj$1, y) ) );
+			f2( ( obj$2 = { v: v }, obj$2[ w ] = 0, obj$2[ x ] = true, Object.assign(obj$2, y) ) );
 			f3( ( obj$3 = {}, obj$3[ w ] = 0, obj$3[ x ] = true, obj$3 ) );
 			f4( ( obj$4 = {}, obj$4[ w ] = 0, obj$4[ x ] = true, obj$4.y = y, obj$4 ) );
-			f5( Object.assign(( obj$5 = { k : 9 }, obj$5[ x ] = true, obj$5 ), y) );
-			f6( Object.assign({}, y, ( obj$6 = {}, obj$6[ x ] = true, obj$6 )) );
-			f7( Object.assign({}, y, ( obj$7 = {}, obj$7[ w ] = 0, obj$7[ x ] = true, obj$7 )) );
-			f8( Object.assign({ k : 9 }, y, ( obj$8 = {}, obj$8[ x ] = true, obj$8 )) );
+			f5( ( obj$5 = { k : 9 }, obj$5[ x ] = true, Object.assign(obj$5, y) ) );
+			f6( ( obj$6 = Object.assign({}, y), obj$6[ x ] = true, obj$6 ) );
+			f7( ( obj$7 = Object.assign({}, y), obj$7[ w ] = 0, obj$7[ x ] = true, obj$7 ) );
+			f8( ( obj$8 = Object.assign({ k : 9 }, y), obj$8[ x ] = true, obj$8 ) );
 			f9( ( obj$9 = {}, obj$9[ x ] = true, obj$9[ y ] = false, obj$9[ z ] = 9, obj$9 ) );
-			f10( Object.assign(( obj$10 = {}, obj$10[ x ] = true, obj$10 ), y, {p: p}, q) );
+			f10( ( obj$10 = {}, obj$10[ x ] = true, Object.assign(obj$10, y), obj$10.p = p, Object.assign(obj$10, q) ) );
 			f11( ( obj$11 = { x: x }, obj$11[c] = 9, obj$11.y = y, obj$11 ) );
-			f12(Object.assign({}, b, ( obj$12 = {}, obj$12[c] = 3, obj$12 ), {d:4}));
+			f12(( obj$12 = Object.assign({}, b), obj$12[c] = 3, obj$12.d = 4, obj$12 ));
 		`
 	},
 
@@ -199,8 +230,17 @@ module.exports = [
 		options: {
 			objectAssign: 'Object.assign'
 		},
-		input: `var obj = { ...a, b: 1, dd: {...d, f: 1}, e};`,
-		output: `var obj = Object.assign({}, a, {b: 1, dd: Object.assign({}, d, {f: 1}), e: e});`
+		input: `
+			var obj = { ...a, b: 1, dd: {...d, f: 1}, e};
+		`,
+		output: `
+			var obj$1;
+
+			var obj = Object.assign({}, a);
+			obj.b = 1;
+			obj.dd = ( obj$1 = Object.assign({}, d), obj$1.f = 1, obj$1 );
+			obj.e = e;
+		`
 	},
 
 	{
@@ -208,8 +248,17 @@ module.exports = [
 		options: {
 			objectAssign: 'Object.assign'
 		},
-		input: `const c = { ...a, b: 1, dd: {...d, f: 1, gg: {h, ...g, ii: {...i}}}, e};`,
-		output: `var c = Object.assign({}, a, {b: 1, dd: Object.assign({}, d, {f: 1, gg: Object.assign({}, {h: h}, g, {ii: Object.assign({}, i)})}), e: e});`
+		input: `
+			const c = { ...a, b: 1, dd: {...d, f: 1, gg: {h, ...g, ii: {...i}}}, e};
+		`,
+		output: `
+			var obj, obj$1;
+
+			var c = Object.assign({}, a);
+			c.b = 1;
+			c.dd = ( obj$1 = Object.assign({}, d), obj$1.f = 1, obj$1.gg = ( obj = Object.assign({h: h}, g), obj.ii = Object.assign({}, i), obj ), obj$1 );
+			c.e = e;
+		`
 	},
 
 	{
@@ -217,8 +266,17 @@ module.exports = [
 		options: {
 			objectAssign: 'angular.extend'
 		},
-		input: `var obj = { ...a, b: 1, dd: {...d, f: 1}, e};`,
-		output: `var obj = angular.extend({}, a, {b: 1, dd: angular.extend({}, d, {f: 1}), e: e});`
+		input: `
+			var obj = { ...a, b: 1, dd: {...d, f: 1}, e};
+		`,
+		output: `
+			var obj$1;
+
+			var obj = angular.extend({}, a);
+			obj.b = 1;
+			obj.dd = ( obj$1 = angular.extend({}, d), obj$1.f = 1, obj$1 );
+			obj.e = e;
+		`
 	},
 
 	{
@@ -308,8 +366,13 @@ for( var rest = objectWithoutProperties( c, [] ), b = rest;; ) {}`
 		options: {
 			objectAssign: 'Object.assign'
 		},
-		input: `var obj = { ...{a: 1}, b: 2, ...c, e};`,
-		output: `var obj = Object.assign({}, {a: 1, b: 2}, c, {e: e});`
+		input: `
+			var obj = { ...{a: 1}, b: 2, ...c, e};
+		`,
+		output: `
+			var obj = Object.assign({ a: 1, b: 2}, c);
+			obj.e = e;
+		`
 	},
 
 	{
@@ -326,12 +389,44 @@ for( var rest = objectWithoutProperties( c, [] ), b = rest;; ) {}`
 			obj = { a: 1, ...{b: 2,}, };
 		`,
 		output: `
-			var obj = Object.assign({}, {a: 1, b: 2, c: 3}, d, {e: e, f: 6});
+			var obj = Object.assign({ a: 1, b: 2, c: 3}, d);
+			obj.e = e;
+			obj.f = 6;
 			obj = { a: 1, b: 2, };
 			obj = { a: 1, b: 2 };
 			obj = { a: 1, b: 2 };
 			obj = { a: 1, b: 2, };
 			obj = { a: 1, b: 2, };
+		`
+	},
+
+	{
+		description: 'does not inline object spread with getters',
+		options: {
+			objectAssign: 'Object.assign'
+		},
+		input: `
+			var obj = { a: 1, ...{ b: 2, get c() { return 3; } }, d: 4 };
+		`,
+		output: `
+			var obj = Object.assign({ a: 1 }, { b: 2, get c() { return 3; } });
+			obj.d = 4;
+		`
+	},
+
+	{
+		description: 'does not inline object spread with getters when mixed',
+		options: {
+			objectAssign: 'Object.assign'
+		},
+		input: `
+			var obj = { a: 1, [ x ]: 2, ...{ get c() { return 3; } }, ...d, e };
+		`,
+		output: `
+			var obj = { a: 1 };
+			obj[ x ] = 2;
+			Object.assign(obj, { get c() { return 3; } }, d);
+			obj.e = e;
 		`
 	}
 ];


### PR DESCRIPTION
The new implementation has less code, more comments, and passes more
tests.

The design of the algorithm is detailed in comments; the only major
change to note is that the output has changed to be more conservative
with object creation. For example, `x = { ...a, b }` now compiles to

  `x = Object.assign({}, a); x.b = b`

instead of

  `x = Object.assign({}, a, {b: b})`

So generated programs that previously executed without problems may be
different now, although they will hopefully still execute without
problems.

---
GitHub doesn't display this diff very well; more of this code is unchanged than is evident. In particular, the block with all the TODO comments is untouched from the original. Whatever bugs lie in wait there, I probably didn't make them worse.

Fixes #163, fixes #203, fixes #212.